### PR TITLE
Switching from selfcorrecting to plain relaxation

### DIFF
--- a/example/multiphase/d2q9_pf_velocity/deforming_ferro_droplet_repeats.xml
+++ b/example/multiphase/d2q9_pf_velocity/deforming_ferro_droplet_repeats.xml
@@ -63,20 +63,19 @@
 	<Param name="Hy_far" value="0.0308"/>
 	<Param name="Hx_far" value="0.0000"/>
 
-	<Param name="relaxation" value="0.2"/>
+	<Param name="relaxation" value="0.078"/>
 
 	<Param name="BuoyancyY" value="0.0000" />
 </Model>
 <VTK />
-<Repeat Times="5">
-	<Repeat Times="2000"> 
+<Repeat Times="100">
+	<Repeat Times="100"> 
 		<Container>
-			<Stop DiffBBelow="1e-7" Times="2" Iterations="500"/>
-			<RunAction name="MagToSteadyState" Iterations="10000"/>
+			<Stop DiffBBelow="1e-3" Times="2" Iterations="100"/>
+			<RunAction name="MagToSteadyState" Iterations="1000000"/>
 		</Container>
-		<Solve Iterations="1.0"/>
+		<Solve Iterations="1"/>
 	</Repeat>
 	<VTK/>
 </Repeat>
-<VTK/>
 </CLBConfig>

--- a/models/multiphase/d2q9_pf_velocity/Dynamics.c.Rt
+++ b/models/multiphase/d2q9_pf_velocity/Dynamics.c.Rt
@@ -414,8 +414,6 @@ CudaDeviceFunction void Init_distributions(){
 	#endif
 
 	#ifdef OPTIONS_ferro
-		Psi_new1 = Hx_far*X + Hy_far*Y;
-		Psi_new2 = Hx_far*X + Hy_far*Y;
 		Psi_old = Hx_far*X + Hy_far*Y;
 		LapPsiSource = 0.0;
 	#endif
@@ -1247,8 +1245,10 @@ CudaDeviceFunction void CollisionMRT(){
 		    lap_psi += Psi_old( 0,-1)*(calc_mu(PhaseF( 0,-1)) + calc_mu(PhaseF(0,0)))/2;
 		    lap_psi += Psi_old( 0, 1)*(calc_mu(PhaseF( 0, 1)) + calc_mu(PhaseF(0,0)))/2;
 		    lap_psi -= Psi_old(0,0) * (calc_mu(PhaseF(1,0)) + calc_mu(PhaseF(0,1)) + calc_mu(PhaseF(-1,0)) + calc_mu(PhaseF(0,-1)) + 4*calc_mu(PhaseF(0,0)))/2;
-		    lap_psi *= 1 - 1/relaxation;
-		    lap_psi *= 1/getmu();
+//		    lap_psi *= 1 - 1/relaxation;
+//		    lap_psi *= 1/getmu();
+		} else {
+			lap_psi = 0;
 		}
 		LapPsiSource = lap_psi;
 	}
@@ -1257,56 +1257,8 @@ CudaDeviceFunction void CollisionMRT(){
 		return LapPsiSource;
 	}
 
-	CudaDeviceFunction void Mag_Poisson12(){
 
-		Psi_new2 = (Psi_new1(-1,0) + Psi_new1(1,0) + Psi_new1(0,1) + Psi_new1(0,-1) - LapPsiSource)/4;
-
-		switch  (NodeType & NODE_ADDITIONALS)  {
-			case NODE_North:
-				Psi_new2 = Psi_new1(0,-1) + Hy_far;
-				break;
-			case NODE_South:
-				Psi_new2 = Psi_new1(0,1) - Hy_far;
-				break;
-			case NODE_East:
-				Psi_new2 = Psi_new1(-1,0) + Hx_far;
-				break;
-			case NODE_West:
-				Psi_new2 = Psi_new1(1,0) - Hx_far;
-				break;
-		}
-	}
-
-	CudaDeviceFunction void Mag_Poisson21(){
-
-		Psi_new1 = (Psi_new2(-1,0) + Psi_new2(1,0) + Psi_new2(0,1) + Psi_new2(0,-1) - LapPsiSource)/4;
-
-		switch  (NodeType & NODE_ADDITIONALS)  {
-			case NODE_North:
-				Psi_new1 = Psi_new2(0,-1) + Hy_far;
-				break;
-			case NODE_South:
-				Psi_new1 = Psi_new2(0,1) - Hy_far;
-				break;
-			case NODE_East:
-				Psi_new1 = Psi_new2(-1,0) + Hx_far;
-				break;
-			case NODE_West:
-				Psi_new1 = Psi_new2(1,0) - Hx_far;
-				break;
-		}
-	}
-
-	CudaDeviceFunction void FinaliseMagUpdate(){
-		real_t psinew = Psi_old(0,0) + relaxation * (Psi_new2(0,0) - Psi_old(0,0));
-		Psi_new1 = psinew;
-		Psi_old = psinew;
-		AddToDiffB(fabs(Psi_new2(0,0) - Psi_old(0,0)));
-		//AddToDivB(calcDivB());
-	}
-
-
-	CudaDeviceFunction void FerroCopy(){
+	CudaDeviceFunction void SolvePoisson(){
 	    // Save everything from buffer 1 to 2.
 	    g[0] = g0(0,0);
 	    g[1] = g1(0,0);
@@ -1334,12 +1286,28 @@ CudaDeviceFunction void CollisionMRT(){
 
 	    PhaseF = PhaseF(0,0);
 
-	    Psi_old = Psi_old(0,0); 
-	    Psi_new1 = Psi_new1(0,0);
-	    Psi_new2 = Psi_new2(0,0);
+//	    LapPsiSource = LapPsiSource(0,0);
+		calcPsiSource();
 
-	    LapPsiSource = LapPsiSource(0,0);
+	    real_t oldPsi = Psi_old(0,0);
+	    real_t newPsi = oldPsi + relaxation * LapPsiSource;
 
+		switch  (NodeType & NODE_ADDITIONALS)  {
+			case NODE_North:
+				newPsi = Psi_old(0,-1) + Hy_far;
+				break;
+			case NODE_South:
+				newPsi = Psi_old(0,1) - Hy_far;
+				break;
+			case NODE_East:
+				newPsi = Psi_old(-1,0) + Hx_far;
+				break;
+			case NODE_West:
+				newPsi = Psi_old(1,0) - Hx_far;
+				break;
+		}
+	    Psi_old = newPsi;
+	    AddToDiffB(fabs(oldPsi - newPsi));
 	}
 
 	CudaDeviceFunction vector_t calcMagForce (){


### PR DESCRIPTION
OK. I don't understand all what is happening in this model, but I don't know if this "self-correcting" approach really works well. I switched it to just `psi = psi + relax * (nabla(mu nabla psi))` and it works pretty fine. The convergence is slow, but only for the initial conditions really, later it's fast. And all in all it runs quite fast. I think it can be further optimized by using a fixed number of iterations at later stages.

@wattrg @TravisMitchell Have a look and see if this approach works better for you.

![ferro_drop0](https://user-images.githubusercontent.com/1880696/106728041-ce0bcd80-6657-11eb-918e-ec27f01b0b66.png)
![ferro_drop1](https://user-images.githubusercontent.com/1880696/106728044-cf3cfa80-6657-11eb-8e3d-b1aeb0d84909.png)
Just a numerical node: `relax` has to be below `1/(4*max(mu))` for stability.
